### PR TITLE
Update psycopg2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup( name='postgres'
      , url='https://postgres-py.readthedocs.org'
      , version='2.2.1-dev'
      , packages=find_packages()
-     , install_requires=['psycopg2 >= 2.5.0']
+     , install_requires=['psycopg2-binary >= 2.7.5']
      , classifiers=[
          'Development Status :: 5 - Production/Stable',
          'Intended Audience :: Developers',


### PR DESCRIPTION
**Description:**
The `psycopg2` package is renaming their wheel package to `psycopg2-binary`: http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released

> For the lifespan of the Psycopg 2.7 cycle, the psycopg2 PyPI package will still contain wheel packages, but starting from Psycopg 2.8 it will become again a source-only package.

Importing `postgres` currently results in this warning:

```
UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
```

Updating `psycopg2 >= 2.5.0` to `psycopg2-binary >= 2.7.5` fixes the issue - tested locally.