### PR TITLE
Database connection paramaters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
   - pip install pytest ./
 before_script:
   - psql -U postgres -c 'CREATE DATABASE "test";'
-  - psql -U postgres -c 'CREATE USER jrandom SUPERUSER;'
 script:
   - ./runtests.sh
 branches:

--- a/postgres/__init__.py
+++ b/postgres/__init__.py
@@ -290,6 +290,11 @@ class Postgres(object):
     registration of typecasters with :mod:`psycopg2` to ensure that you get
     unicode instead of bytestrings for text data, according to `this advice`_.)
 
+    The `libpq environment variables
+    <https://www.postgresql.org/docs/current/libpq-envars.html>`_ are used to
+    determine the connection paramaters which are not explicitly passed in the
+    :attr:`url` argument.
+
     When instantiated, this object creates a `thread-safe connection pool
     <http://initd.org/psycopg/docs/pool.html#psycopg2.pool.ThreadedConnectionPool>`_,
     which opens :attr:`minconn` connections immediately, and up to
@@ -321,7 +326,7 @@ class Postgres(object):
 
     """
 
-    def __init__(self, url, minconn=1, maxconn=10, \
+    def __init__(self, url='', minconn=1, maxconn=10, \
                                         cursor_factory=SimpleNamedTupleCursor):
         if url.startswith("postgres://"):
             dsn = url_to_dsn(url)

--- a/postgres/__init__.py
+++ b/postgres/__init__.py
@@ -32,7 +32,7 @@ Tutorial
 Instantiate a :class:`Postgres` object when your application starts:
 
     >>> from postgres import Postgres
-    >>> db = Postgres("postgres://jrandom@localhost/test")
+    >>> db = Postgres()
 
 Use :meth:`~postgres.Postgres.run` to run SQL statements:
 
@@ -284,7 +284,7 @@ class Postgres(object):
     wants to talk to using this library.
 
     >>> import postgres
-    >>> db = postgres.Postgres("postgres://jrandom@localhost/test")
+    >>> db = postgres.Postgres()
 
     (Note that importing :mod:`postgres` under Python 2 will cause the
     registration of typecasters with :mod:`psycopg2` to ensure that you get
@@ -866,7 +866,7 @@ def make_DelegatingCaster(postgres):
 
 
 if __name__ == '__main__':
-    db = Postgres("postgres://jrandom@localhost/test")
+    db = Postgres()
     db.run("DROP SCHEMA IF EXISTS public CASCADE")
     db.run("CREATE SCHEMA public")
     import doctest

--- a/postgres/cursors.py
+++ b/postgres/cursors.py
@@ -54,18 +54,14 @@ class SimpleCursorBase(object):
     ...     pass
     ...
     >>> from postgres import Postgres
-    >>> db = Postgres( "postgres://jrandom@localhost/test"
-    ...              , cursor_factory=SimpleLoggingCursor
-    ...               )
+    >>> db = Postgres(cursor_factory=SimpleLoggingCursor)
 
     If you try to use a cursor that doesn't subclass
     :class:`~postgres.cursors.SimpleCursorBase` as the default
     :attr:`cursor_factory` for a :class:`~postgres.Postgres` instance, we
     won't let you:
 
-    >>> db = Postgres( "postgres://jrandom@localhost/test"
-    ...              , cursor_factory=LoggingCursor
-    ...               )
+    >>> db = Postgres(cursor_factory=LoggingCursor)
     ...
     Traceback (most recent call last):
         ...
@@ -178,7 +174,7 @@ def isexception(obj):
 
 if __name__ == '__main__':
     from postgres import Postgres
-    db = Postgres("postgres://jrandom@localhost/test")
+    db = Postgres()
     db.run("DROP SCHEMA IF EXISTS public CASCADE")
     db.run("CREATE SCHEMA public")
     import doctest

--- a/postgres/orm.py
+++ b/postgres/orm.py
@@ -257,7 +257,7 @@ class Model(object):
 if __name__ == '__main__':
 
     from postgres import Postgres
-    db = Postgres("postgres://jrandom@localhost/test")
+    db = Postgres()
     db.run("DROP SCHEMA IF EXISTS public CASCADE")
     db.run("CREATE SCHEMA public")
     db.run("DROP TABLE IF EXISTS foo CASCADE")

--- a/runtests.sh
+++ b/runtests.sh
@@ -5,8 +5,10 @@
 # fix them because fixing them would make the docs uglier. As long as the
 # doctests pass for Python 3 then we know the doc examples are good.
 
+if [ "$PGDATABASE" = "" ]; then export PGDATABASE="test"; fi
+
 function run_pytests() {
-    DATABASE_URL=postgres://jrandom@localhost/test py.test tests.py -v && return 0 || return 1
+    py.test tests.py -v && return 0 || return 1
 }
 
 function run_doctests() {

--- a/tests.py
+++ b/tests.py
@@ -11,16 +11,13 @@ from psycopg2 import InterfaceError, ProgrammingError
 from pytest import mark, raises
 
 
-DATABASE_URL = os.environ['DATABASE_URL']
-
-
 # harnesses
 # =========
 
 class WithSchema(TestCase):
 
     def setUp(self):
-        self.db = Postgres(DATABASE_URL, cursor_factory=SimpleDictCursor)
+        self.db = Postgres(cursor_factory=SimpleDictCursor)
         self.db.run("DROP SCHEMA IF EXISTS public CASCADE")
         self.db.run("CREATE SCHEMA public")
 
@@ -367,7 +364,7 @@ class TestORM(WithData):
 class TestCursorFactory(WithData):
 
     def setUp(self):                    # override
-        self.db = Postgres(DATABASE_URL)
+        self.db = Postgres()
         self.db.run("DROP SCHEMA IF EXISTS public CASCADE")
         self.db.run("CREATE SCHEMA public")
         self.db.run("CREATE TABLE foo (bar text, baz int)")


### PR DESCRIPTION
This branch makes the `url` argument of `Postgres()` optional and documents the fact that the [libpq environment variables](https://www.postgresql.org/docs/current/libpq-envars.html) are used to determine the connection parameters. It also removes the hardcoded database URLs from the tests and docstrings, in order to simplify development (no need to create a `jrandom` user to run the tests).