### PR TITLE
Improve the `.one()` and `.all()` methods

### DIFF
--- a/postgres/cursors.py
+++ b/postgres/cursors.py
@@ -98,23 +98,29 @@ class SimpleCursorBase(object):
         """
 
         # fetch
-        out = self._some(sql, parameters, lo=0, hi=1)
-        if out:
-            assert len(out) == 1
-            out = out[0]
-        else:
-            out = None
-
-        # dereference
-        if out is not None and len(out) == 1:
-            seq = list(out.values()) if hasattr(out, 'values') else out
-            out = seq[0]
-
-        # default
-        if out is None:
+        self.execute(sql, parameters)
+        if self.rowcount == 1:
+            out = self.fetchone()
+        elif self.rowcount == 0:
             if isexception(default):
                 raise default
-            out = default
+            return default
+        elif self.rowcount < 0:
+            raise TooFew(self.rowcount, 0, 1)
+        else:
+            raise TooMany(self.rowcount, 0, 1)
+
+        # dereference
+        if len(out) == 1:
+            try:
+                out = out[0]
+            except LookupError:
+                if callable(getattr(out, 'values', None)):
+                    out = tuple(out.values())[0]
+            if out is None:
+                if isexception(default):
+                    raise default
+                return default
 
         return out
 
@@ -140,11 +146,13 @@ class SimpleCursorBase(object):
         """
         self.execute(sql, parameters)
         recs = self.fetchall()
-        if recs and len(recs[0]) == 1:          # dereference
-            if hasattr(recs[0], 'values'):      # mapping
-                recs = [list(rec.values())[0] for rec in recs]
-            else:                               # sequence
+        if recs and len(recs[0]) == 1:
+            # dereference
+            try:
                 recs = [rec[0] for rec in recs]
+            except LookupError:
+                if callable(getattr(recs[0], 'values', None)):
+                    recs = [tuple(rec.values())[0] for rec in recs]
         return recs
 
 

--- a/postgres/cursors.py
+++ b/postgres/cursors.py
@@ -125,17 +125,6 @@ class SimpleCursorBase(object):
         return out
 
 
-    def _some(self, sql, parameters, lo, hi):
-        self.execute(sql, parameters)
-
-        if self.rowcount < lo:
-            raise TooFew(self.rowcount, lo, hi)
-        elif self.rowcount > hi:
-            raise TooMany(self.rowcount, lo, hi)
-
-        return self.fetchall()
-
-
     def all(self, sql, parameters=None):
         """Execute a query and return all results.
 

--- a/tests.py
+++ b/tests.py
@@ -101,29 +101,11 @@ class TestWrongNumberException(WithData):
         assert actual == "Got -1 rows; expecting 0 or 1."
 
     def test_TooMany_message_is_helpful_for_two_options(self):
-        try:
-            with self.db.get_cursor() as cursor:
-                actual = cursor._some( "SELECT * FROM foo"
-                                     , parameters=None
-                                     , lo=1
-                                     , hi=1
-                                      )
-        except TooMany as exc:
-            actual = str(exc)
+        actual = str(TooMany(2, 1, 1))
         assert actual == "Got 2 rows; expecting exactly 1."
 
     def test_TooMany_message_is_helpful_for_a_range(self):
-        self.db.run("INSERT INTO foo VALUES ('blam')")
-        self.db.run("INSERT INTO foo VALUES ('blim')")
-        try:
-            with self.db.get_cursor() as cursor:
-                actual = cursor._some( "SELECT * FROM foo"
-                                     , parameters=None
-                                     , lo=1
-                                     , hi=3
-                                      )
-        except TooMany as exc:
-            actual = str(exc)
+        actual = str(TooMany(4, 1, 3))
         assert actual == "Got 4 rows; expecting between 1 and 3 (inclusive)."
 
 

--- a/tests.py
+++ b/tests.py
@@ -145,12 +145,39 @@ class TestOneOrZero(WithData):
         actual = self.db.one("SELECT * FROM foo WHERE bar='blam'")
         assert actual is None
 
-    def test_one_returns_whatever(self):
+    def test_one_returns_default(self):
         class WHEEEE: pass
         actual = self.db.one( "SELECT * FROM foo WHERE bar='blam'"
                             , default=WHEEEE
                              )
         assert actual is WHEEEE
+
+    def test_one_raises_default(self):
+        exception = RuntimeError('oops')
+        try:
+            actual = self.db.one( "SELECT * FROM foo WHERE bar='blam'"
+                                , default=exception
+                                 )
+        except Exception as e:
+            if e is not exception:
+                raise
+        else:
+            raise AssertionError('exception not raised')
+
+    def test_one_returns_default_after_derefencing(self):
+        default = 0
+        actual = self.db.one("SELECT NULL AS foo", default=default)
+        assert actual is default
+
+    def test_one_raises_default_after_derefencing(self):
+        exception = RuntimeError('oops')
+        try:
+            self.db.one("SELECT NULL AS foo", default=exception)
+        except Exception as e:
+            if e is not exception:
+                raise
+        else:
+            raise AssertionError('exception not raised')
 
     def test_one_returns_one(self):
         actual = self.db.one("SELECT * FROM foo WHERE bar='baz'")


### PR DESCRIPTION
The starting point of this branch was that the `.one()` and `.all()` methods currently choke on queries like `SELECT values FROM something`, because they assume that a `values` attribute is a callable similar to the `dict.values()` method. This is fixed by changing the condition from `hasattr(out, 'values')` to `callable(getattr(out, 'values', None))`, but while I was at it I also reorganized the code and added a few more tests.