### PR TITLE
Add a `Connection.get_cursor` alias

### DIFF
--- a/postgres/context_managers.py
+++ b/postgres/context_managers.py
@@ -44,18 +44,9 @@ class CursorContextManager(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Put our connection back in the pool.
         """
-        conn = self.conn
-        if conn.autocommit:
-            pass
-        elif exc_type is None and conn.readonly is False:
-            conn.commit()
-        else:
-            try:
-                conn.rollback()
-            except InterfaceError:
-                pass
         self.cursor.close()
-        self.pool.putconn(conn)
+        self.conn.__exit__(exc_type, exc_val, exc_tb)
+        self.pool.putconn(self.conn)
 
 
 class ConnectionContextManager(object):

--- a/tests.py
+++ b/tests.py
@@ -286,6 +286,15 @@ class TestConnection(WithData):
         except Heck:
             pass
 
+    def test_connection_has_get_cursor_method(self):
+        with self.db.get_connection() as conn:
+            with conn.get_cursor() as cursor:
+                cursor.execute("DELETE FROM foo WHERE bar = 'baz'")
+            with conn.get_cursor(cursor_factory=SimpleDictCursor) as cursor:
+                cursor.execute("SELECT * FROM foo ORDER BY bar")
+                actual = cursor.fetchall()
+        assert actual == [{"bar": "buz"}]
+
 
 # orm
 # ===


### PR DESCRIPTION
Closes #61.

*Edit:* on second thought, this approach could be problematic, I'm going to try another one later.

*Edit 2:* done, I moved the `__exit__` method from the cursor subclass to the connection subclass.