### PR TITLE
Add a new row type

### DIFF
--- a/postgres/__init__.py
+++ b/postgres/__init__.py
@@ -181,8 +181,10 @@ import psycopg2
 from inspect import isclass
 from postgres.context_managers import ConnectionContextManager
 from postgres.context_managers import CursorContextManager
-from postgres.cursors import SimpleTupleCursor, SimpleNamedTupleCursor
-from postgres.cursors import SimpleDictCursor, SimpleCursorBase
+from postgres.cursors import (
+    Row, SimpleCursorBase, SimpleDictCursor, SimpleNamedTupleCursor,
+    SimpleRowCursor, SimpleTupleCursor,
+)
 from postgres.orm import Model
 from psycopg2 import DataError, InterfaceError, ProgrammingError
 from psycopg2.extras import register_composite, CompositeCaster
@@ -274,7 +276,9 @@ default_back_as_registry = {
     namedtuple: SimpleNamedTupleCursor,
     'namedtuple': SimpleNamedTupleCursor,
     dict: SimpleDictCursor,
-    'dict': SimpleDictCursor
+    'dict': SimpleDictCursor,
+    Row: SimpleRowCursor,
+    'Row': SimpleRowCursor,
 }
 
 


### PR DESCRIPTION
This branch adds an alternative to representing query results as namedtuples or dicts.

The new `Row` class supports both item and attribute lookups and assignments. Unlike namedtuples these hybrid rows are mutable, and they're all instances of a single class.

I tried to submit this upstream, but it didn't go well (<https://github.com/psycopg/psycopg2/pull/970>).