### PR TITLE
Add support for subtransactions

### DIFF
--- a/postgres/context_managers.py
+++ b/postgres/context_managers.py
@@ -49,6 +49,32 @@ class CursorContextManager(object):
         self.pool.putconn(self.conn)
 
 
+class CursorSubcontextManager(object):
+    """Wraps a cursor so that it can be used for a subtransaction.
+
+    See :meth:`~postgres.Postgres.get_cursor` for an explanation of subtransactions.
+
+    :param cursor: the :class:`psycopg2:cursor` to wrap
+    :param back_as: temporarily overwrites the cursor's
+        :attr:`~postgres.cursors.SimpleCursorBase.back_as` attribute
+
+    """
+
+    __slots__ = ('cursor', 'back_as', 'outer_back_as')
+
+    def __init__(self, cursor, back_as=None):
+        self.cursor = cursor
+        self.back_as = back_as
+
+    def __enter__(self):
+        self.outer_back_as = self.cursor.back_as
+        self.cursor.back_as = self.back_as
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cursor.back_as = self.outer_back_as
+
+
 class ConnectionContextManager(object):
     """Instantiated once per :func:`~postgres.Postgres.get_connection` call.
 

--- a/postgres/cursors.py
+++ b/postgres/cursors.py
@@ -79,6 +79,11 @@ class SimpleCursorBase(object):
         ...
     AttributeError: 'LoggingCursor' object has no attribute 'all'
 
+    .. attribute:: back_as
+
+        Determines which type of row is returned by the various methods. The valid
+        values are the keys of the :attr:`~postgres.Postgres.back_as_registry`.
+
     """
 
     back_as = None

--- a/tests.py
+++ b/tests.py
@@ -268,6 +268,28 @@ class TestCursor(WithData):
         except ReadOnlySqlTransaction:
             pass
 
+    def test_get_cursor_supports_subtransactions(self):
+        before_count = self.db.one("SELECT count(*) FROM foo")
+        with self.db.get_cursor() as outer_cursor:
+            outer_cursor.execute("INSERT INTO foo VALUES ('lorem')")
+            with self.db.get_cursor(cursor=outer_cursor) as inner_cursor:
+                assert inner_cursor is outer_cursor
+                inner_cursor.execute("INSERT INTO foo VALUES ('ipsum')")
+        after_count = self.db.one("SELECT count(*) FROM foo")
+        assert after_count == (before_count + 2)
+
+    def test_subtransactions_do_not_swallow_exceptions(self):
+        before_count = self.db.one("SELECT count(*) FROM foo")
+        try:
+            with self.db.get_cursor() as cursor:
+                cursor.execute("INSERT INTO foo VALUES ('lorem')")
+                with self.db.get_cursor(cursor=cursor) as c:
+                    raise Heck
+        except Heck:
+            pass
+        after_count = self.db.one("SELECT count(*) FROM foo")
+        assert after_count == before_count
+
 
 # db.get_connection
 # =================


### PR DESCRIPTION
This branch adds a `cursor` argument to the `get_cursor` method. The rationale for this is in <https://github.com/chadwhitacre/postgres.py/issues/40#issuecomment-535371832>.